### PR TITLE
Add execution control

### DIFF
--- a/src/client/Program.cs
+++ b/src/client/Program.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-
+using OwlDomain.Owlish.Engine.Execution;
 using OwlDomain.Owlish.Engine.Input;
 
 namespace OwlDomain.Owlish;
@@ -23,6 +23,7 @@ public static class Program
 
 		HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(settings);
 		builder.Services.AddHostedService<OwlishWorker>();
+		builder.Services.AddSingleton<IExecutionService, ExecutionService>();
 
 		IHost host = builder.Build();
 
@@ -32,7 +33,11 @@ public static class Program
 	#endregion
 }
 
-class OwlishWorker(IHostApplicationLifetime lifetime, IConfiguration configuration) : BackgroundService
+class OwlishWorker(
+	IHostApplicationLifetime lifetime,
+	IConfiguration configuration,
+	IExecutionService execution)
+	: BackgroundService
 {
 	#region Nested types
 	private readonly record struct Position(int Left, int Top)
@@ -222,18 +227,16 @@ class OwlishWorker(IHostApplicationLifetime lifetime, IConfiguration configurati
 		Process? process = null;
 		try
 		{
-			process = Process.Start(startInfo);
-			if (process is null)
-			{
-				// Todo(Nightowl): Fail somehow?
-				return;
-			}
-
+			process = execution.Execute(startInfo, true);
 			await WaitForProcessAsync(process, cancellationToken);
 		}
+#if DEBUG
+		catch (Win32Exception exception)
+#else
 		catch (Exception exception)
+#endif
 		{
-			Console.Error.WriteLine(exception.Message);
+			Console.Error.WriteLine($"Error occurred during execution: \"{exception.Message}\"");
 		}
 		finally
 		{

--- a/src/client/Program.cs
+++ b/src/client/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using OwlDomain.Owlish.Engine;
 using OwlDomain.Owlish.Engine.Execution;
 using OwlDomain.Owlish.Engine.Input;
 
@@ -22,6 +23,12 @@ public static class Program
 		};
 
 		HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(settings);
+
+		// Replace default console lifetime.
+		builder.Services.Remove(builder.Services.Single(descriptor => descriptor.ServiceType == typeof(IHostLifetime)));
+		builder.Services.AddSingleton<IHostLifetime, ConsoleLifetime>();
+
+		// Regular configuration
 		builder.Services.AddHostedService<OwlishWorker>();
 		builder.Services.AddSingleton<IExecutionService, ExecutionService>();
 

--- a/src/engine/Engine/Common/ReaderWriterLockSlimExtensions.cs
+++ b/src/engine/Engine/Common/ReaderWriterLockSlimExtensions.cs
@@ -1,0 +1,72 @@
+namespace OwlDomain.Owlish.Engine.Common;
+
+/// <summary>
+/// 	Represents a read lock around the given <paramref name="readerWriterLock"/>.
+/// </summary>
+/// <param name="readerWriterLock">The reader/writer lock.</param>
+public readonly ref struct ReadLock(ReaderWriterLockSlim readerWriterLock) : IDisposable
+{
+	#region Properties
+	/// <inheritdoc/>
+	public void Dispose() => readerWriterLock.ExitReadLock();
+	#endregion
+}
+
+/// <summary>
+/// 	Represents a write lock around the given <paramref name="readerWriterLock"/>.
+/// </summary>
+/// <param name="readerWriterLock">The reader/writer lock.</param>
+public readonly ref struct WriteLock(ReaderWriterLockSlim readerWriterLock) : IDisposable
+{
+	#region Properties
+	/// <inheritdoc/>
+	public void Dispose() => readerWriterLock.ExitWriteLock();
+	#endregion
+}
+
+/// <summary>
+/// 	Represents an upgradeable read lock around the given <paramref name="readerWriterLock"/>.
+/// </summary>
+/// <param name="readerWriterLock">The reader/writer lock.</param>
+public readonly ref struct UpgradeableReadLock(ReaderWriterLockSlim readerWriterLock) : IDisposable
+{
+	#region Properties
+	/// <inheritdoc/>
+	public void Dispose() => readerWriterLock.ExitUpgradeableReadLock();
+	#endregion
+}
+
+/// <summary>
+/// 	Contains various extension methods related to the <see cref="ReaderWriterLockSlim"/>.
+/// </summary>
+public static class ReaderWriterLockSlimExtensions
+{
+	extension(ReaderWriterLockSlim slim)
+	{
+		#region Methods
+		/// <summary>Enters a read lock.</summary>
+		/// <returns>A disposable which will exit the read lock.</returns>
+		public ReadLock ReadLock()
+		{
+			slim.EnterReadLock();
+			return new(slim);
+		}
+
+		/// <summary>Enters a write lock.</summary>
+		/// <returns>A disposable which will exit the write lock.</returns>
+		public WriteLock WriteLock()
+		{
+			slim.EnterWriteLock();
+			return new(slim);
+		}
+
+		/// <summary>Enters an upgradeable read lock.</summary>
+		/// <returns>A disposable which will exit the upgradeable read lock.</returns>
+		public UpgradeableReadLock UpgradeableReadLock()
+		{
+			slim.EnterUpgradeableReadLock();
+			return new(slim);
+		}
+		#endregion
+	}
+}

--- a/src/engine/Engine/ConsoleLifetime.cs
+++ b/src/engine/Engine/ConsoleLifetime.cs
@@ -1,0 +1,176 @@
+// Most of this implementation has been taken from the Microsoft.Extensions.Hosting.ConsoleLifetime
+// class which is licensed under the MIT license.
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace OwlDomain.Owlish.Engine;
+
+/// <summary>
+/// 	An application lifetime that listens for Ctrl+C or SIGTERM and initiates shutdown when appropriate.
+/// </summary>
+public sealed class ConsoleLifetime : IHostLifetime, IDisposable
+{
+	#region Fields
+	private CancellationTokenRegistration _applicationStartedRegistration;
+	private CancellationTokenRegistration _applicationStoppingRegistration;
+
+	private PosixSignalRegistration? _sigIntRegistration;
+	private PosixSignalRegistration? _sigQuitRegistration;
+	private PosixSignalRegistration? _sigTermRegistration;
+	#endregion
+
+	#region Properties
+	private ConsoleLifetimeOptions Options { get; }
+	private IHostEnvironment Environment { get; }
+	private IHostApplicationLifetime ApplicationLifetime { get; }
+	private HostOptions HostOptions { get; }
+	private ILogger Logger { get; }
+	#endregion
+
+	#region Constructors
+	/// <summary>
+	/// Initializes a <see cref="ConsoleLifetime"/> instance using the specified console lifetime options, host environment, host application lifetime, and host options.
+	/// </summary>
+	/// <param name="options">An object used to retrieve <see cref="ConsoleLifetimeOptions"/> instances.</param>
+	/// <param name="environment">Information about the hosting environment an application is running in.</param>
+	/// <param name="applicationLifetime">An object that allows consumers to be notified of application lifetime events.</param>
+	/// <param name="hostOptions">An object used to retrieve internal host options instances.</param>
+	/// <exception cref="ArgumentNullException"><paramref name="options"/> or <paramref name="environment"/> or <paramref name="applicationLifetime"/> or <paramref name="hostOptions"/> is <see langword="null"/>.</exception>
+	public ConsoleLifetime(IOptions<ConsoleLifetimeOptions> options, IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, IOptions<HostOptions> hostOptions)
+		 : this(options, environment, applicationLifetime, hostOptions, NullLoggerFactory.Instance) { }
+
+	/// <summary>
+	/// Initializes a <see cref="ConsoleLifetime"/> instance using the specified console lifetime options, host environment, host options, and logger factory.
+	/// </summary>
+	/// <param name="options">An object used to retrieve <see cref="ConsoleLifetimeOptions"/> instances.</param>
+	/// <param name="environment">Information about the hosting environment an application is running in.</param>
+	/// <param name="applicationLifetime">An object that allows consumers to be notified of application lifetime events.</param>
+	/// <param name="hostOptions">An object used to retrieve <see cref="HostOptions"/> instances.</param>
+	/// <param name="loggerFactory">An object to configure the logging system and create instances of <see cref="ILogger"/> from the registered <see cref="ILoggerProvider"/>.</param>
+	/// <exception cref="ArgumentNullException"><paramref name="options"/> or <paramref name="environment"/> or <paramref name="applicationLifetime"/> or <paramref name="hostOptions"/> or <paramref name="loggerFactory"/> is <see langword="null"/>.</exception>
+	public ConsoleLifetime(IOptions<ConsoleLifetimeOptions> options, IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, IOptions<HostOptions> hostOptions, ILoggerFactory loggerFactory)
+	{
+		ArgumentNullException.ThrowIfNull(options?.Value, nameof(options));
+		ArgumentNullException.ThrowIfNull(applicationLifetime);
+		ArgumentNullException.ThrowIfNull(environment);
+		ArgumentNullException.ThrowIfNull(hostOptions?.Value, nameof(hostOptions));
+		ArgumentNullException.ThrowIfNull(loggerFactory);
+
+		Options = options.Value;
+		Environment = environment;
+		ApplicationLifetime = applicationLifetime;
+		HostOptions = hostOptions.Value;
+		Logger = loggerFactory.CreateLogger("Microsoft.Hosting.Lifetime");
+	}
+	#endregion
+
+	#region Methods
+	/// <summary>
+	/// Registers the application start, application stop and shutdown handlers for this application.
+	/// </summary>
+	/// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
+	/// <returns>A <see cref="Task"/> that represents the asynchronous registration operation.</returns>
+	public Task WaitForStartAsync(CancellationToken cancellationToken)
+	{
+		if (!Options.SuppressStatusMessages)
+		{
+			_applicationStartedRegistration = ApplicationLifetime.ApplicationStarted.Register(state =>
+			{
+				((ConsoleLifetime)state!).OnApplicationStarted();
+			},
+			this);
+			_applicationStoppingRegistration = ApplicationLifetime.ApplicationStopping.Register(state =>
+			{
+				((ConsoleLifetime)state!).OnApplicationStopping();
+			},
+			this);
+		}
+
+		RegisterShutdownHandlers();
+
+		// Console applications start immediately.
+		return Task.CompletedTask;
+	}
+	private void OnApplicationStarted()
+	{
+		if (Logger.IsEnabled(LogLevel.Information))
+		{
+			Logger.LogInformation("Application started. Press Ctrl+C to shut down.");
+			Logger.LogInformation("Hosting environment: {EnvName}", Environment.EnvironmentName);
+			Logger.LogInformation("Content root path: {ContentRoot}", Environment.ContentRootPath);
+		}
+	}
+
+	/// <summary>
+	/// This method does nothing.
+	/// </summary>
+	/// <param name="cancellationToken">A cancellation token instance.</param>
+	/// <returns>A <see cref="Task"/> that represents a completed task.</returns>
+	public Task StopAsync(CancellationToken cancellationToken)
+	{
+		// There's nothing to do here
+		return Task.CompletedTask;
+	}
+	private void OnApplicationStopping()
+	{
+		Logger.LogInformation("Application is shutting down...");
+	}
+
+	/// <summary>
+	/// Unregisters the shutdown handlers and disposes the application start and application stop registrations.
+	/// </summary>
+	public void Dispose()
+	{
+		UnregisterShutdownHandlers();
+
+		_applicationStartedRegistration.Dispose();
+		_applicationStoppingRegistration.Dispose();
+	}
+	#endregion
+
+	#region Helpers
+	private void HandlePosixSignal(PosixSignalContext context)
+	{
+		Debug.Assert(context.Signal == PosixSignal.SIGINT || context.Signal == PosixSignal.SIGQUIT || context.Signal == PosixSignal.SIGTERM);
+
+		context.Cancel = true;
+		ApplicationLifetime.StopApplication();
+	}
+	private void HandleWindowsShutdown(PosixSignalContext context)
+	{
+		// for SIGTERM on Windows we must block this thread until the application is finished
+		// otherwise the process will be killed immediately on return from this handler
+
+		// don't allow Dispose to unregister handlers, since Windows has a lock that prevents the unregistration while this handler is running
+		// just leak these, since the process is exiting
+		_sigIntRegistration = null;
+		_sigQuitRegistration = null;
+		_sigTermRegistration = null;
+
+		ApplicationLifetime.StopApplication();
+
+		// We could wait for a signal here, like Dispose as is done in non-netcoreapp case, but those inevitably could have user
+		// code that runs after them in the user's Main. Instead we just block this thread completely and let the main routine exit.
+		Thread.Sleep(HostOptions.ShutdownTimeout);
+	}
+	private void RegisterShutdownHandlers()
+	{
+		if (!OperatingSystem.IsWasi())
+		{
+			Action<PosixSignalContext> handler = HandlePosixSignal;
+			_sigIntRegistration = PosixSignalRegistration.Create(PosixSignal.SIGINT, handler);
+			_sigQuitRegistration = PosixSignalRegistration.Create(PosixSignal.SIGQUIT, handler);
+			_sigTermRegistration = PosixSignalRegistration.Create(PosixSignal.SIGTERM, OperatingSystem.IsWindows() ? HandleWindowsShutdown : handler);
+		}
+	}
+	private void UnregisterShutdownHandlers()
+	{
+		_sigIntRegistration?.Dispose();
+		_sigQuitRegistration?.Dispose();
+		_sigTermRegistration?.Dispose();
+	}
+	#endregion
+}

--- a/src/engine/Engine/ConsoleLifetime.cs
+++ b/src/engine/Engine/ConsoleLifetime.cs
@@ -134,27 +134,34 @@ public sealed class ConsoleLifetime : IHostLifetime, IDisposable
 	#region Helpers
 	private void HandlePosixSignal(PosixSignalContext context)
 	{
-		Debug.Assert(context.Signal == PosixSignal.SIGINT || context.Signal == PosixSignal.SIGQUIT || context.Signal == PosixSignal.SIGTERM);
+		Debug.Assert(context.Signal is PosixSignal.SIGINT or PosixSignal.SIGQUIT or PosixSignal.SIGTERM);
 
 		context.Cancel = true;
-		ApplicationLifetime.StopApplication();
+		// Note(Nightowl): Leaving the default implementation here just in case;
+		// ApplicationLifetime.StopApplication();
 	}
 	private void HandleWindowsShutdown(PosixSignalContext context)
 	{
-		// for SIGTERM on Windows we must block this thread until the application is finished
-		// otherwise the process will be killed immediately on return from this handler
+		context.Cancel = true;
+		return;
 
-		// don't allow Dispose to unregister handlers, since Windows has a lock that prevents the unregistration while this handler is running
-		// just leak these, since the process is exiting
-		_sigIntRegistration = null;
-		_sigQuitRegistration = null;
-		_sigTermRegistration = null;
+		// Note(Nightowl): Leaving the default implementation here just in case;
+		/*
+			// for SIGTERM on Windows we must block this thread until the application is finished
+			// otherwise the process will be killed immediately on return from this handler
 
-		ApplicationLifetime.StopApplication();
+			// don't allow Dispose to unregister handlers, since Windows has a lock that prevents the unregistration while this handler is running
+			// just leak these, since the process is exiting
+			_sigIntRegistration = null;
+			_sigQuitRegistration = null;
+			_sigTermRegistration = null;
 
-		// We could wait for a signal here, like Dispose as is done in non-netcoreapp case, but those inevitably could have user
-		// code that runs after them in the user's Main. Instead we just block this thread completely and let the main routine exit.
-		Thread.Sleep(HostOptions.ShutdownTimeout);
+			ApplicationLifetime.StopApplication();
+
+			// We could wait for a signal here, like Dispose as is done in non-netcoreapp case, but those inevitably could have user
+			// code that runs after them in the user's Main. Instead we just block this thread completely and let the main routine exit.
+			Thread.Sleep(HostOptions.ShutdownTimeout);
+		*/
 	}
 	private void RegisterShutdownHandlers()
 	{

--- a/src/engine/Engine/Execution/ExecutionService.cs
+++ b/src/engine/Engine/Execution/ExecutionService.cs
@@ -1,0 +1,79 @@
+namespace OwlDomain.Owlish.Engine.Execution;
+
+/// <summary>
+/// 	Represents a service for controlling the execution of child processes.
+/// </summary>
+public sealed class ExecutionService : IExecutionService
+{
+	#region Fields
+	private readonly List<Process> _active = [];
+	private readonly List<Process> _main = [];
+	private readonly ReaderWriterLockSlim _lock = new();
+	#endregion
+
+	#region Properties
+	/// <inheritdoc/>
+	public IReadOnlyCollection<Process> Active
+	{
+		get
+		{
+			// Note(Nightowl): Wasteful but simpler so I don't care right now;
+			using (_lock.ReadLock())
+				return _active.ToArray();
+		}
+	}
+
+	/// <inheritdoc/>
+	public IReadOnlyCollection<Process> Main
+	{
+		get
+		{
+			// Note(Nightowl): Wasteful but simpler so I don't care right now;
+			using (_lock.ReadLock())
+				return _main.ToArray();
+		}
+	}
+	#endregion
+
+	#region Methods
+	/// <inheritdoc/>
+	public Process Execute(ProcessStartInfo startInfo, bool isMain)
+	{
+		Process? process = Process.Start(startInfo);
+		if (process is null)
+			ThrowHelper.ThrowArgumentException(nameof(startInfo), "The process couldn't be executed, something was probably wrong with the start info.");
+
+		Debug.WriteLine($"Executed process '{startInfo.FileName}' PID: {process.Id}.");
+
+		void Handler(object? sender, EventArgs args)
+		{
+			Debug.WriteLine($"Execution process stopped PID: {process.Id}.");
+			process.Exited -= Handler;
+
+			using (_lock.WriteLock())
+			{
+				_active.Remove(process);
+
+				if (isMain)
+					_main.Remove(process);
+			}
+		}
+
+		process.Exited += Handler;
+		process.EnableRaisingEvents = true;
+
+		if (process.HasExited is false)
+		{
+			using (_lock.WriteLock())
+			{
+				_active.Add(process);
+
+				if (isMain)
+					_main.Add(process);
+			}
+		}
+
+		return process;
+	}
+	#endregion
+}

--- a/src/engine/Engine/Execution/IExecutionService.cs
+++ b/src/engine/Engine/Execution/IExecutionService.cs
@@ -1,0 +1,28 @@
+namespace OwlDomain.Owlish.Engine.Execution;
+
+/// <summary>
+/// 	Represents a service for controlling the execution of child processes.
+/// </summary>
+public interface IExecutionService
+{
+	#region Properties
+	/// <summary>The collection of the active processes.</summary>
+	IReadOnlyCollection<Process> Active { get; }
+
+	/// <summary>The main processes that are being executed.</summary>
+	/// <remarks>This represents the processes being ran directly by the user through commands.</remarks>
+	IReadOnlyCollection<Process> Main { get; }
+	#endregion
+
+	#region Methods
+	/// <summary>Executes a new process.</summary>
+	/// <param name="startInfo">The information to use to start the process.</param>
+	/// <param name="isMain">Whether the started process should be considered as one of the main processes.</param>
+	/// <returns>The started process.</returns>
+	/// <remarks>
+	/// 	This method will not perform any validation if the process fails to start,
+	/// 	and instead it'll forward the exceptions to the caller to handle.
+	/// </remarks>
+	Process Execute(ProcessStartInfo startInfo, bool isMain);
+	#endregion
+}

--- a/src/engine/Engine/global/global.Project.cs
+++ b/src/engine/Engine/global/global.Project.cs
@@ -1,4 +1,5 @@
 global using CommunityToolkit.Diagnostics;
 
+global using OwlDomain.Owlish.Engine.Common;
 global using OwlDomain.Owlish.Engine.Common.Diagnostics;
 global using OwlDomain.Owlish.Engine.Common.Text;


### PR DESCRIPTION
So originally this pull request was meant to fix #18 by adding in a tracker for started child processes and then killing them.

But as it turns out Ctrl+C automatically kills the child-processes and then kills our process, so this was kinda pointless. However I believe this will still be useful later when handling job control so I'm keeping it in.

The primary change in the pull request besides this is replacing the default console lifetime so that it doesn't quit when it receives Ctrl+C/SIGTERM *(maybe it should still quit with SIGTERM, unsure).* This is still fine because we handle Ctrl+C during command input so the user can still quit this way when needed, it's just no longer forced by the lifetime, meaning that the user can cancel command execution without exiting the shell.